### PR TITLE
Add clean stopping with CTRL+C

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { Readable } = require('bare-stream')
 const ansiEscapes = require('bare-ansi-escapes')
 const KeyDecoder = require('bare-ansi-escapes/key-decoder')
+const process = require('process')
 
 const constants = {
   EOL: '\r\n'
@@ -71,12 +72,18 @@ const Readline = module.exports = exports = class Readline extends Readable {
 
     switch (key.name) {
       case 'd':
-        if (key.ctrl) return this.close()
+        if (key.ctrl) {
+          this.close()
+          return process.exit()
+        }
         characters = key.shift ? 'D' : 'd'
         break
 
       case 'c':
-        if (key.ctrl) return this.close()
+        if (key.ctrl) {
+          this.close()
+          return process.exit()
+        }
         characters = key.shift ? 'C' : 'c'
         break
 


### PR DESCRIPTION
In raw mode, CTRL+C, which typically generates a SIGINT (interrupt signal) to terminate a process, will not function as it normally does. The raw mode is defined by that: `rl.input.setMode(tty.constants.MODE_RAW)` 

I would therefore suggest to add `process.stop()` for both CTRL+C and CTRL+D

Could be a Windows [problem ](https://github.com/microsoft/terminal/issues/5128) but does including it would not harm other OS.

Best