### PR TITLE
Add support for \n as end of line inputs which trigger `line` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ const Readline = module.exports = exports = class Readline extends Readable {
 
       case 'backspace': return this._onbackspace()
 
+      case 'linefeed':
       case 'return': {
         const line = this.line
         if (line.trim() === '') return ''
@@ -95,7 +96,6 @@ const Readline = module.exports = exports = class Readline extends Readable {
       case 'right': return this._onright()
       case 'left': return this._onleft()
 
-      case 'linefeed':
       case 'escape':
       case 'f1': case 'f2': case 'f3': case 'f4': case 'f5': case 'f6':
       case 'f7': case 'f8': case 'f9': case 'f10': case 'f11': case 'f12':

--- a/test.js
+++ b/test.js
@@ -40,7 +40,7 @@ test('supports linefeed as line event', (t) => {
   input.write('\n')
 })
 
-test.skip('supports \\r\\n as single line event', (t) => {
+test('supports \\r\\n as single line event', (t) => {
   t.plan(2)
 
   const input = new PassThrough()

--- a/test.js
+++ b/test.js
@@ -20,3 +20,41 @@ test('basic', (t) => {
   input.write('hello world')
   input.write('\r')
 })
+
+test('supports linefeed as line event', (t) => {
+  t.plan(2)
+
+  const input = new PassThrough()
+  const rl = new Readline({ input })
+
+  rl
+    .on('line', (line) => {
+      t.is(line, 'hello world')
+      rl.close()
+    })
+    .on('close', () => {
+      t.pass('closed')
+    })
+
+  input.write('hello world')
+  input.write('\n')
+})
+
+test.skip('supports \\r\\n as single line event', (t) => {
+  t.plan(2)
+
+  const input = new PassThrough()
+  const rl = new Readline({ input })
+
+  rl
+    .on('line', (line) => {
+      t.is(line, 'hello world')
+      rl.close()
+    })
+    .on('close', () => {
+      t.pass('closed')
+    })
+
+  input.write('hello world')
+  input.write('\r\n')
+})


### PR DESCRIPTION
I discovered that I wasn't able to trigger a `line` event pressing return in my terminal and it seems to be cause by my terminal input using `\n` instead of `\r`. Per the [nodejs readline docs](https://nodejs.org/api/readline.html#event-line):
> The 'line' event is emitted whenever the input stream receives an end-of-line input (\n, \r, or \r\n).

I also added a test for `\r\n`, but it is skipped as it doesn't pass yet due to `bare-ansi-escapes` not parsing multiple characters in the input stream's chunk. https://github.com/holepunchto/bare-ansi-escapes/pull/3 would fix this from my testing.