### PR TITLE
Remove pausing stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ module.exports = exports = class Readline extends Readable {
       this._output.on('resize', this._onresize)
       this._onresize()
     }
+
+    this.resume()
   }
 
   get input() {

--- a/index.js
+++ b/index.js
@@ -32,14 +32,12 @@ module.exports = exports = class Readline extends Readable {
     this._rows = defaultRows
     this._sawReturn = 0
 
-    this.on('data', this._ondata).setEncoding('utf8').pause()
+    this.on('data', this._ondata).setEncoding('utf8')
 
     if (this._output) {
       this._output.on('resize', this._onresize)
       this._onresize()
     }
-
-    this.resume()
   }
 
   get input() {

--- a/test.js
+++ b/test.js
@@ -85,3 +85,19 @@ test('emit empty line on return', (t) => {
 
   input.write('\r')
 })
+
+test('emit line event', (t) => {
+  t.plan(2)
+
+  const input = new PassThrough()
+  const rl = Readline.createInterface({ input })
+
+  rl.on('line', (line) => {
+    t.is(line, 'hello world')
+    rl.close()
+  }).on('close', () => {
+    t.pass('closed')
+  })
+
+  input.write('hello world\n')
+})


### PR DESCRIPTION
NodeJS implementation is not paused initially. Assuming that the pause was for a potential immediate `_onresize()` the instance is resumed at the end of the constructor.

Added test as evidence of both the `line` event working for NodeJS capability and evidence of the stream being resumed since the `line` event is derived from the stream `data` event. Finally the `line` event is how I found the bug.