### PR TITLE
failing test for using for/await with readline

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = exports = class Readline extends Readable {
   }
 
   _onnewlistener(name) {
-    if (name === 'line') this.resume()
+    if (name === 'line') this.resume() // For Node.js compatibility
   }
 
   _oninput(data) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = exports = class Readline extends Readable {
     this._rows = defaultRows
     this._sawReturn = 0
 
-    this.on('data', this._ondata).setEncoding('utf8')
+    this.on('newListener', this._onnewlistener).setEncoding('utf8')
 
     if (this._output) {
       this._output.on('resize', this._onresize)
@@ -116,6 +116,10 @@ module.exports = exports = class Readline extends Readable {
     return line
   }
 
+  _onnewlistener(name) {
+    if (name === 'line') this.resume()
+  }
+
   _oninput(data) {
     this._decoder.write(data)
   }
@@ -125,10 +129,6 @@ module.exports = exports = class Readline extends Readable {
     this._columns = columns
     this._rows = rows
     this.prompt()
-  }
-
-  _ondata(line) {
-    this.emit('line', line) // For Node.js compatibility
   }
 
   _online(linefeed) {
@@ -148,6 +148,7 @@ module.exports = exports = class Readline extends Readable {
     if (remember && line !== this._history.get(0)) this._history.unshift(line)
 
     this.push(line)
+    this.emit('line', line) // For Node.js compatibility
 
     if (remember) this.emit('history', this._history.entries)
   }

--- a/test.js
+++ b/test.js
@@ -101,3 +101,26 @@ test('emit line event', (t) => {
 
   input.write('hello world\n')
 })
+
+test('for-await readline instance', async (t) => {
+  const input = new PassThrough()
+  const rl = Readline.createInterface({ input })
+
+  const lines = []
+
+  rl.on('close', () => {
+    t.is('hello world', lines.join(' '))
+    t.pass('closed')
+  })
+
+  input.write('hello\n')
+  input.write('world\n')
+
+  for await (const chunk of rl) {
+    lines.push(chunk.toString())
+
+    if (lines.length == 2) {
+      rl.close()
+    }
+  }
+})


### PR DESCRIPTION
I found this debugging some nodejs code that expects to be able to use for/await with readline.

Removing `this.on('data', this._ondata).setEncoding('utf8')` from the readline constructor resolves this test, but of course breaks all the others 😅

Not sure yet what a solution might look like but wanted to make the failing test before I forgot about this.